### PR TITLE
Assigned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ pub trait VecScoped<T>: VecScopedPrivate<Element = T> {
         Pop::new(self)
     }
 
-    fn update(&mut self, idx: usize, value: T) -> Update<Self> {
+    fn update(&mut self, idx: usize, value: T) -> Update<Self>
+    where
+        Self: Sized,
+    {
         Update::new(self, value, idx)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,14 +148,13 @@ impl<'a, T, V: VecScopedPrivate<Element = T>> VecScoped<T> for Push<'a, V> {}
 pub struct Assign<'a, V: VecScopedPrivate>(&'a mut V, usize, Option<V::Element>);
 
 impl<'a, V: VecScopedPrivate> Assign<'a, V> {
-    pub fn new(vec_scoped: &'a mut V, value: V::Element, idx: usize) -> Self {
+    pub fn new(vec_scoped: &'a mut V, mut value: V::Element, idx: usize) -> Self {
         let inner = vec_scoped.vec_mut();
-        // i think this is efficient?
-        let old = inner.swap_remove(idx);
-        let end = inner.len();
-        inner.push(value);
-        inner.swap(end, idx);
-        Self(vec_scoped, idx, Some(old))
+        if let Some(old) = inner.get_mut(idx) {
+            let temp = &mut value;
+            std::mem::swap(old, temp);
+        }
+        Self(vec_scoped, idx, Some(value))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ impl<'a, V: VecScopedPrivate> Assign<'a, V> {
     }
 }
 
-impl<'a, T, V: std::ops::Deref<Target = [T]> + VecScopedPrivate> std::ops::Deref for Assign<'a, V> {
+impl<'a, T, V: Deref<Target = [T]> + VecScopedPrivate> Deref for Assign<'a, V> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ impl<'a, T, V: std::ops::Deref<Target = [T]> + VecScopedPrivate> std::ops::Deref
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        std::ops::Deref::deref(self.0)
+        &*self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,12 +260,7 @@ fn test_assigned() {
 #[test]
 #[should_panic]
 fn test_assigned_panics_with_out_of_bounds_index() {
-    let mut a = vec![1];
-    {
-        // panics here
-        assert_eq!([1], *a.assigned(2, 5))
-    }
-    assert_eq!([1], *a);
+    vec![1].assigned(2, 5);
 }
 
 // TODO automatically verify that this warns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,12 @@ impl<'a, V: VecScopedPrivate> Assign<'a, V> {
         if let Some(old) = inner.get_mut(idx) {
             let temp = &mut value;
             std::mem::swap(old, temp);
+        } else {
+            panic!(
+                "assigned index (is {}) should be < len (is {})",
+                idx,
+                inner.len()
+            )
         }
         Self {
             inner: vec_scoped,
@@ -235,12 +241,23 @@ fn test_pop_push() {
 }
 
 #[test]
-fn test_update() {
+fn test_assigned() {
     let mut a = vec![0, 1, 2, 3];
     {
         assert_eq!([0, 1, 5, 3], *a.assigned(2, 5))
     }
     assert_eq!([0, 1, 2, 3], *a);
+}
+
+#[test]
+#[should_panic]
+fn test_assigned_panics_with_out_of_bounds_index() {
+    let mut a = vec![1];
+    {
+        // panics here
+        assert_eq!([1], *a.assigned(2, 5))
+    }
+    assert_eq!([1], *a);
 }
 
 // TODO automatically verify that this warns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,12 +236,6 @@ fn test_pop_push() {
 
 #[test]
 fn test_update() {
-    let mut a = vec![1];
-    {
-        assert_eq!([-1], *a.assigned(0, -1));
-    }
-    assert_eq!([1], *a);
-
     let mut a = vec![0, 1, 2, 3];
     {
         assert_eq!([0, 1, 5, 3], *a.assigned(2, 5))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ fn test_update() {
 
     let mut a = vec![0, 1, 2, 3];
     {
-        assert_eq!([0, 1, 5, 3, 6], *a.update(2, 5))
+        assert_eq!([0, 1, 5, 3], *a.update(2, 5))
     }
     assert_eq!([0, 1, 2, 3], *a);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,7 @@ impl<'a, V: VecScopedPrivate> Assign<'a, V> {
     pub fn new(vec_scoped: &'a mut V, mut value: V::Element, idx: usize) -> Self {
         let inner = vec_scoped.vec_mut();
         if let Some(old) = inner.get_mut(idx) {
-            let temp = &mut value;
-            std::mem::swap(old, temp);
+            std::mem::swap(old, &mut value);
         } else {
             panic!(
                 "assigned index (is {}) should be < len (is {})",
@@ -185,8 +184,7 @@ impl<'a, V: VecScopedPrivate> Drop for Assign<'a, V> {
         let idx = self.idx;
         let inner = self.inner.vec_mut();
         if let Some(old) = inner.get_mut(idx) {
-            let temp = &mut self.previous;
-            std::mem::swap(old, temp);
+            std::mem::swap(old, &mut self.previous);
         } else {
             panic!(
                 "dropping assigned index (is {}) should be < len (is {}), this should never happen",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,11 @@ pub struct Update<'a, V: VecScopedPrivate>(&'a mut V, usize, Option<V::Element>)
 impl<'a, V: VecScopedPrivate> Update<'a, V> {
     pub fn new(vec_scoped: &'a mut V, value: V::Element, idx: usize) -> Self {
         let inner = vec_scoped.vec_mut();
-        let old = inner.remove(idx);
-        inner.insert(idx, value);
+        // i think this is efficient?
+        let old = inner.swap_remove(idx);
+        let end = inner.len();
+        inner.push(value);
+        inner.swap(end, idx);
         Self(vec_scoped, idx, Some(old))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub trait VecScoped<T>: VecScopedPrivate<Element = T> {
         Pop::new(self)
     }
 
+    /// Temporarily assign an element at `idx` of the `Vec`.
+    /// Panics if `idx` is out of bounds.
     fn assigned(&mut self, idx: usize, value: T) -> Assign<Self>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ impl<'a, T, V: VecScopedPrivate<Element = T>> VecScoped<T> for Push<'a, V> {}
 pub struct Assign<'a, V: VecScopedPrivate> {
     inner: &'a mut V,
     idx: usize,
-    assigned: Option<V::Element>,
+    previous: Option<V::Element>,
 }
 
 impl<'a, V: VecScopedPrivate> Assign<'a, V> {
@@ -167,7 +167,7 @@ impl<'a, V: VecScopedPrivate> Assign<'a, V> {
         Self {
             inner: vec_scoped,
             idx,
-            assigned: Some(value),
+            previous: Some(value),
         }
     }
 }
@@ -183,7 +183,7 @@ impl<'a, T, V: Deref<Target = [T]> + VecScopedPrivate> Deref for Assign<'a, V> {
 impl<'a, V: VecScopedPrivate> Drop for Assign<'a, V> {
     fn drop(&mut self) {
         let idx = self.idx;
-        if let Some(old) = self.assigned.take() {
+        if let Some(old) = self.previous.take() {
             self.vec_mut()[idx] = old;
         }
     }


### PR DESCRIPTION
this is my stab at it. i think it _works_ but it might be pretty inefficient? i thought there would be a function that removed an item from the array, let me take ownership of that item, and replaced it with a new item all at once, but i didn't see this if it exists. the `drop` implementation does a simple replace, because it does not need to take ownership.

there is this function, which isn't exactly what i want: https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap_remove but maybe i still want to use it?

also, interestingly, i had to use the option type, as you do in the `pop` struct, so that i can take ownership again of the value i changed with `.take()` when i change it back. is this the best way?